### PR TITLE
Don't try to process the nil JSON body

### DIFF
--- a/CBAFusionOBJC/Classes/View Model/AuthenticationService.m
+++ b/CBAFusionOBJC/Classes/View Model/AuthenticationService.m
@@ -133,6 +133,7 @@ API_AVAILABLE(ios(13))
                                                                    fromData:data completionHandler:^(NSData *data,NSURLResponse *response,NSError *error) {
             if (error != nil) {
                 NSLog(@"ERROR");
+                return;
             }
             
             NSLog(@"SUCCESS WITH RESPONSE %@", response);


### PR DESCRIPTION
If the server is typed incorrectly, the `URLSession` completion handler will fire with a non-`nil` `error` and a `nil` `data` instance. When we pass that `nil` instance into `[NSJSONSerialization JSONObjectWithData:data options:0 error:&error]` a crash is generated.

This change performs an early return when a non-`nil` error is received.