### PR TITLE
Request permissions when the UI appears, not when a call is made

### DIFF
--- a/CBAFusionOBJC/Classes/Phone/PhoneViewController.m
+++ b/CBAFusionOBJC/Classes/Phone/PhoneViewController.m
@@ -44,14 +44,14 @@ static NSString *const RINGTONE_FILE = @"ringring";
     [self.uc.phone setDelegate:self];
     //IF YOU DO NOT START THE AUDIO SESSION YOU CANNOT USE THE MANAGER PROPERLY!
     [self.uc.phone.audioDeviceManager start];
+    [self requestMicrophoneAndCameraPermissionFromAppSettings];
 }
 
 
 /// We Show Case how to use both programatic UIView's and Storyboards
 - (void) setupPhone:(void (^)(void))completionHandler {
     provAlerts = [[NSMutableArray alloc] init];
-    [self requestMicrophoneAndCameraPermissionFromAppSettings];
-    
+
     // Default the audio and video to be enabled on start of call
     audioAllowed = [AppSettings preferredAudioDirection] == ACBMediaDirectionReceiveOnly || [AppSettings preferredAudioDirection] == ACBMediaDirectionSendAndReceive;
     videoAllowed = [AppSettings preferredVideoDirection] == ACBMediaDirectionReceiveOnly || [AppSettings preferredVideoDirection] == ACBMediaDirectionSendAndReceive;


### PR DESCRIPTION
The request for camera / mic permissions now happens as soon as the call screen appears. Previously, it would happen "just in time", either when a call was initiated, or a call was incoming. This was too late and resulted in the 1st call failing.

With this change, the 1st call will now succeed.