### PR TITLE
Allow sip: entries into the text field

### DIFF
--- a/CBAFusionOBJC/Base.lproj/MainStoryboard_iPhone.storyboard
+++ b/CBAFusionOBJC/Base.lproj/MainStoryboard_iPhone.storyboard
@@ -793,7 +793,7 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet" textContentType="url"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
Make the text field accept alphanumerics, specifically for adding support for sip: URLs.

We can still use the given number pad for direct numeric entry, so we don't need a keyboard with `keyboardType` of `numberPad`.

![IMG_0081](https://github.com/cbajapan/CBAFusionObjc/assets/12008876/3432ee42-2da9-4eff-9a59-55f39e37c213)
